### PR TITLE
Use wall clock to determine afk session duration

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 			if time.Now().After(endTime) {
 				break
 			}
-			time.Sleep(1 * time.Second)
+			time.Sleep(time.Second)
 		}
 		fmt.Println("New status expired")
 		stopEvents <- stopEvent{resumePreviousStatus: true}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	flag.Parse()
 
 	endTime := time.Now().Add(duration)
-	// By default, Go uses a monotonic clock for measuring time. However if the computer goes to sleep during an afk session, the monotonic clock may stop. This will cause the afk session to end later than the user expected. Therefore, we remove the monotonic time value so that calculations will use the wall clock time will be used instead. The canonical way to strip a monotonic clock reading is to use t = t.Round(0). See https://pkg.go.dev/time for more information.
+	// By default, Go uses a monotonic clock for measuring time. If the computer goes to sleep during an afk session, the monotonic clock may stop. When the computer wakes, the monotonic clock will resume from where it stopped. This will cause the afk session to end later than the user expected since the duration that the computer was sleeping is not counted toward the afk session. Therefore, we remove the monotonic time value so that calculations will use the wall clock time instead. The canonical way to strip a monotonic clock reading is to use t = t.Round(0). See https://pkg.go.dev/time for more information.
 	endTime = endTime.Round(0)
 
 	originalStatus := getCurrentStatus()

--- a/main.go
+++ b/main.go
@@ -98,7 +98,6 @@ func main() {
 	}()
 
 	go func() {
-		time.Sleep(time.Second)
 		for {
 			if time.Now().After(endTime) {
 				break

--- a/main.go
+++ b/main.go
@@ -52,6 +52,10 @@ func main() {
 	flag.BoolVar(&doNotDisturb, "dnd", false, "Enable Do Not Disturb")
 	flag.Parse()
 
+	endTime := time.Now().Add(duration)
+	// By default, Go uses a monotonic clock for measuring time. However if the computer goes to sleep during an afk session, the monotonic clock may stop. This will cause the afk session to end later than the user expected. Therefore, we remove the monotonic time value so that calculations will use the wall clock time will be used instead. The canonical way to strip a monotonic clock reading is to use t = t.Round(0). See https://pkg.go.dev/time for more information.
+	endTime = endTime.Round(0)
+
 	originalStatus := getCurrentStatus()
 	fmt.Printf("=== Current Status ===\n%v\n", originalStatus.String())
 	fmt.Println("")
@@ -59,7 +63,7 @@ func main() {
 	newStatus := slackStatus{
 		StatusEmoji:      emoji,
 		StatusText:       message,
-		StatusExpiration: time.Now().Add(duration).Unix(),
+		StatusExpiration: endTime.Unix(),
 	}
 
 	// set new status
@@ -94,7 +98,13 @@ func main() {
 	}()
 
 	go func() {
-		time.Sleep(duration)
+		time.Sleep(time.Second)
+		for {
+			if time.Now().After(endTime) {
+				break
+			}
+			time.Sleep(1 * time.Second)
+		}
 		fmt.Println("New status expired")
 		stopEvents <- stopEvent{resumePreviousStatus: true}
 	}()


### PR DESCRIPTION
Fixes #4 

By default, Go uses a monotonic clock for measuring time. If the computer goes to sleep during an afk session, the monotonic clock may stop. When the computer wakes, the monotonic clock will resume from where it stopped. This will cause the afk session to end later than the user expected since the duration that the computer was sleeping is not counted toward the afk session. Therefore, we remove the monotonic time value so that calculations will use the wall clock time instead. The canonical way to strip a monotonic clock reading is to use `t = t.Round(0)`. See https://pkg.go.dev/time for more information.

This was surprising to me so included the paragraph above as a code comment also.

It took me while to figure out this bug because it was seemingly random. 😅 Then one day I was reading the [time package docs](https://pkg.go.dev/time) while working on another project and noticed the following:

> Operating systems provide both a “wall clock,” which is subject to changes for clock synchronization, and a “monotonic clock,” which is not. The general rule is that the wall clock is for telling time and the monotonic clock is for measuring time. Rather than split the API, in this package the Time returned by [time.Now](https://pkg.go.dev/time#Now) contains both a wall clock reading and a monotonic clock reading; later time-telling operations use the wall clock reading, but later time-measuring operations, specifically comparisons and subtractions, use the monotonic clock reading.

That was interesting on it's own because I was unfamiliar with monotonic clocks, but it wasn't until I read the following sentence a few paragraphs later that I realized the relevance to #4:

> On some systems the monotonic clock will stop if the computer goes to sleep. On such a system, t.Sub(u) may not accurately reflect the actual time that passed between t and u. The same applies to other functions and methods that subtract times, such as [Since](https://pkg.go.dev/time#Since), [Until](https://pkg.go.dev/time#Until), [Time.Before](https://pkg.go.dev/time#Time.Before), [Time.After](https://pkg.go.dev/time#Time.After), [Time.Add](https://pkg.go.dev/time#Time.Add), [Time.Equal](https://pkg.go.dev/time#Time.Equal) and [Time.Compare](https://pkg.go.dev/time#Time.Compare). In some cases, you may need to strip the monotonic clock to get accurate results.

💡 That's why this bug seemed to happen "randomly". It only occurred on afk sessions that were long enough that my computer went to sleep (e.g. a lunch break). Because the monotonic clock stops while the computer sleeps, that duration wasn't being included in the afk session duration calculation so the session was effectively `requested afk session duration + computer sleep duration`. That explains the surprising behavior I noted in https://github.com/leejones/afk/issues/4#issuecomment-1121396679:

> Strangely, I've noticed at least 3 different times that if I set a duration (e.g. 1 hour), it seems to exit about that duration (e.g. 1 hour) after when it was supposed to. I haven't done comprehensive testing and am not sure if it does this consistently.

My computer goes to sleep after 20 mins of inactivity so here's the example timeline of an 1h afk session before this bug fix:

| Wall Clock Time | Elapsed Time (minutes) | Monotonic Time (minutes)[^1] | Event |
| --- | --- | --- | --- |
| 12:00 | 00 | 00 | `afk --duration 1h --message Lunch` |
| 12:20 | 20 | 20 | Computer goes to sleep |
| 1:00 | 60 | 20 | Computer wakes when I return from lunch, but `afk` continues |
| 1:40 | 100 |  60 | `afk` session finishes |

[^1]: The monotonic time would likely be some high number relative to when the computer started, but here I show as relative to the first event for ease of understanding.